### PR TITLE
Format dates to ISO8601 in ingestion

### DIFF
--- a/fhirflat/ingest.py
+++ b/fhirflat/ingest.py
@@ -254,6 +254,8 @@ def convert_data_to_flat(
     mapping_files_types: tuple[dict, dict] | None = None,
     sheet_id: str | None = None,
     subject_id="subjid",
+    date_format="%Y-%m-%d",
+    timezone=None,
 ):
     """
     Takes raw clinical data (currently assumed to be a one-row-per-patient format like
@@ -334,5 +336,8 @@ def convert_data_to_flat(
             raise ValueError(f"Unknown mapping type {t}")
 
         resource.ingest_to_flat(
-            df, os.path.join(folder_name, resource.__name__.lower())
+            df,
+            os.path.join(folder_name, resource.__name__.lower()),
+            date_format,
+            timezone,
         )

--- a/fhirflat/ingest.py
+++ b/fhirflat/ingest.py
@@ -76,7 +76,7 @@ def find_field_value(
     return return_val
 
 
-def format_dates(date_str: str, date_format: str, timezone=str) -> dict:
+def format_dates(date_str: str, date_format: str, timezone: str) -> dict:
     """
     Converts dates into ISO8601 format with timezone information.
     """
@@ -212,7 +212,7 @@ def create_dictionary(
     one_to_one=False,
     subject_id="subjid",
     date_format="%Y-%m-%d",
-    timezone=None,
+    timezone="UTC",
 ) -> pd.DataFrame | None:
     """
     Given a data file and a single mapping file for one FHIR resource type,

--- a/fhirflat/ingest.py
+++ b/fhirflat/ingest.py
@@ -5,6 +5,9 @@ FHIRflat.
 
 import pandas as pd
 import numpy as np
+from datetime import datetime
+import dateutil.parser
+from zoneinfo import ZoneInfo
 import warnings
 import os
 from math import isnan
@@ -24,44 +27,84 @@ TODO
 """
 
 
-def find_field_value(row, response, mapp, raw_data=None):
+def find_field_value(
+    row, response, fhir_attr, mapp, date_format, timezone, raw_data=None
+):
     """
     Returns the data for a given field, given the mapping.
     For one to many resources the raw data is provided to allow for searching for other
     fields than in the melted data.
     """
     if mapp == "<FIELD>":
-        return response
+        return_val = response
     elif "+" in mapp:
         mapp = mapp.split("+")
-        results = [find_field_value(row, response, m, raw_data) for m in mapp]
+        results = [
+            find_field_value(row, response, "", m, date_format, timezone, raw_data)
+            for m in mapp
+        ]
         results = [str(x) for x in results if not (isinstance(x, float) and isnan(x))]
-        return " ".join(results) if "/" not in results[0] else "".join(results)
+        return_val = " ".join(results) if "/" not in results[0] else "".join(results)
     elif "if not" in mapp:
         mapp = mapp.replace(" ", "").split("ifnot")
-        results = [find_field_value(row, response, m, raw_data) for m in mapp]
+        results = [
+            find_field_value(row, response, "", m, date_format, timezone, raw_data)
+            for m in mapp
+        ]
         x, y = results
         if isinstance(y, float):
-            return x if isnan(y) else None
+            return_val = x if isnan(y) else None
         else:
-            return x if not y else None
+            return_val = x if not y else None
     elif "<" in mapp:
         col = mapp.lstrip("<").rstrip(">")
         try:
-            return row[col]
+            return_val = row[col]
         except KeyError:
             if raw_data is not None:
                 try:
-                    return raw_data.loc[row["index"], col]
+                    return_val = raw_data.loc[row["index"], col]
                 except KeyError:
                     raise KeyError(f"Column {col} not found in data")
             else:
                 raise KeyError(f"Column {col} not found in the filtered data")
     else:
-        return mapp
+        return_val = mapp
+
+    if "date" in fhir_attr.lower() or "period" in fhir_attr.lower():
+        return format_dates(return_val, date_format, timezone)
+    return return_val
 
 
-def create_dict_wide(row: pd.Series, map_df: pd.DataFrame) -> dict:
+def format_dates(date_str: str, date_format: str, timezone=str) -> dict:
+    """
+    Converts dates into ISO8601 format with timezone information.
+    """
+
+    if date_str is None:
+        return date_str
+
+    new_tz = ZoneInfo(timezone)
+
+    try:
+        date_time = datetime.strptime(date_str, date_format)
+        date_time_aware = date_time.replace(tzinfo=new_tz)
+        if "%H" not in date_format:
+            date_time_aware = date_time_aware.date()
+    except ValueError:
+        # Unconverted data remains in the string (i.e. time is present)
+        date, time = date_str.split(" ")
+        date = datetime.strptime(date, date_format)
+        time = dateutil.parser.parse(time).time()
+        date_time = datetime.combine(date, time)
+        date_time_aware = date_time.replace(tzinfo=new_tz)
+
+    return date_time_aware.isoformat()
+
+
+def create_dict_wide(
+    row: pd.Series, map_df: pd.DataFrame, date_format: str, timezone: str
+) -> dict:
     """
     Takes a wide-format dataframe and iterates through the columns of the row,
     applying the mapping to each column and produces a fhirflat-like dictionary to
@@ -83,7 +126,9 @@ def create_dict_wide(row: pd.Series, map_df: pd.DataFrame) -> dict:
                         k: (
                             v
                             if "<" not in str(v)
-                            else find_field_value(row, response, v)
+                            else find_field_value(
+                                row, response, k, v, date_format, timezone
+                            )
                         )
                         for k, v in mapping.items()
                     }
@@ -119,7 +164,11 @@ def create_dict_wide(row: pd.Series, map_df: pd.DataFrame) -> dict:
 
 
 def create_dict_long(
-    row: pd.Series, full_df: pd.DataFrame, map_df: pd.DataFrame
+    row: pd.Series,
+    full_df: pd.DataFrame,
+    map_df: pd.DataFrame,
+    date_format: str,
+    timezone: str,
 ) -> dict | None:
     """
     Takes a long-format dataframe and a mapping file, and produces a fhirflat-like
@@ -139,7 +188,9 @@ def create_dict_long(
                 k: (
                     v
                     if "<" not in str(v)
-                    else find_field_value(row, response, v, raw_data=full_df)
+                    else find_field_value(
+                        row, response, k, v, date_format, timezone, raw_data=full_df
+                    )
                 )
                 for k, v in mapping.items()
             }
@@ -160,6 +211,8 @@ def create_dictionary(
     resource: str,
     one_to_one=False,
     subject_id="subjid",
+    date_format="%Y-%m-%d",
+    timezone=None,
 ) -> pd.DataFrame | None:
     """
     Given a data file and a single mapping file for one FHIR resource type,
@@ -179,6 +232,10 @@ def create_dictionary(
         Whether the resource should be mapped as one-to-one or one-to-many.
     subject_id: str
         The name of the column containing the subject ID in the data file.
+    date_format: str
+        The format of the dates in the data file. E.g. "%Y-%m-%d"
+    timezone: str
+        The timezone of the dates in the data file. E.g. "Europe/London"
     """
 
     data: pd.DataFrame = pd.read_csv(data_file, header=0)
@@ -238,12 +295,12 @@ def create_dictionary(
     # Generate the flat_like dictionary
     if one_to_one:
         filtered_data["flat_dict"] = filtered_data.apply(
-            create_dict_wide, args=[map_df], axis=1
+            create_dict_wide, args=[map_df, date_format, timezone], axis=1
         )
         return filtered_data
     else:
         melted_data["flat_dict"] = melted_data.apply(
-            create_dict_long, args=[data, map_df], axis=1
+            create_dict_long, args=[data, map_df, date_format, timezone], axis=1
         )
         return melted_data["flat_dict"].to_frame()
 
@@ -251,11 +308,11 @@ def create_dictionary(
 def convert_data_to_flat(
     data: str,
     folder_name: str,
+    date_format: str,
+    timezone: str,
     mapping_files_types: tuple[dict, dict] | None = None,
     sheet_id: str | None = None,
     subject_id="subjid",
-    date_format="%Y-%m-%d",
-    timezone=None,
 ):
     """
     Takes raw clinical data (currently assumed to be a one-row-per-patient format like
@@ -268,6 +325,10 @@ def convert_data_to_flat(
         The path to the raw clinical data file.
     folder_name: str
         The name of the folder to store the FHIRflat files.
+    date_format: str
+        The format of the dates in the data file. E.g. "%Y-%m-%d"
+    timezone: str
+        The timezone of the dates in the data file. E.g. "Europe/London"
     mapping_files_types: tuple[dict, dict] | None
         A tuple containing two dictionaries, one with the mapping files for each
         resource type and one with the mapping type (either one-to-one or one-to-many)
@@ -317,6 +378,8 @@ def convert_data_to_flat(
                 resource.__name__,
                 one_to_one=True,
                 subject_id=subject_id,
+                date_format=date_format,
+                timezone=timezone,
             )
             if df is None:
                 continue
@@ -327,6 +390,8 @@ def convert_data_to_flat(
                 resource.__name__,
                 one_to_one=False,
                 subject_id=subject_id,
+                date_format=date_format,
+                timezone=timezone,
             )
             if df is None:
                 continue

--- a/fhirflat/resources/base.py
+++ b/fhirflat/resources/base.py
@@ -153,20 +153,13 @@ class FHIRFlatBase(_DomainResource):
         for date_cols in [
             x for x in flat_df.columns if "date" in x.lower() or "period" in x.lower()
         ]:
-            dti = pd.to_datetime(flat_df[date_cols], format=date_format)
-            dti = dti.dt.tz_localize(timezone)
-            flat_df[date_cols] = dti.dt.strftime("%Y-%m-%dT%H:%M:%S%z")
-
             # replace nan with None
             flat_df[date_cols] = flat_df[date_cols].replace(np.nan, None)
 
-            # remove time & timezone info if none was provided
+            # convert datetime objects to ISO strings
+            # (stops unwanted parquet conversions)
             flat_df[date_cols] = flat_df[date_cols].apply(
-                lambda x: (
-                    (x.split("T")[0] if "T00:00:00" in x else x)
-                    if x is not None
-                    else None
-                )
+                lambda x: (x.isoformat() if x is not None else None)
             )
 
         for coding_column in [

--- a/fhirflat/resources/base.py
+++ b/fhirflat/resources/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fhir.resources.domainresource import DomainResource as _DomainResource
 
 import pandas as pd
+import numpy as np
 import orjson
 
 from fhirflat.fhir2flat import fhir2flat
@@ -127,7 +128,9 @@ class FHIRFlatBase(_DomainResource):
         return condensed_mapped_data
 
     @classmethod
-    def ingest_to_flat(cls, data: pd.DataFrame, filename: str):
+    def ingest_to_flat(
+        cls, data: pd.DataFrame, filename: str, date_format: str, timezone: str
+    ):
         """
         Takes a pandas dataframe and populates the resource with the data.
         Creates a FHIRflat parquet file for the resources.
@@ -146,13 +149,25 @@ class FHIRFlatBase(_DomainResource):
         # flattens resources back out
         flat_df = data["fhir"].apply(lambda x: x.to_flat())
 
-        # Stops parquet conversion from stripping the time from mixed date/datetime
-        # columns
+        # create FHIR expected date format
         for date_cols in [
             x for x in flat_df.columns if "date" in x.lower() or "period" in x.lower()
         ]:
-            flat_df[date_cols] = flat_df[date_cols].astype(str)
-            flat_df[date_cols] = flat_df[date_cols].replace("nan", None)
+            dti = pd.to_datetime(flat_df[date_cols], format=date_format)
+            dti = dti.dt.tz_localize(timezone)
+            flat_df[date_cols] = dti.dt.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+            # replace nan with None
+            flat_df[date_cols] = flat_df[date_cols].replace(np.nan, None)
+
+            # remove time & timezone info if none was provided
+            flat_df[date_cols] = flat_df[date_cols].apply(
+                lambda x: (
+                    (x.split("T")[0] if "T00:00:00" in x else x)
+                    if x is not None
+                    else None
+                )
+            )
 
         for coding_column in [
             x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "pyarrow==15.0.0",
     "pydantic==2.6.1",
     "pydantic_core==2.16.2",
+    "tzdata",
+    "python-dateutil"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -118,7 +118,7 @@ ENCOUNTER_SINGLE_ROW_FLAT = {
         },
     ],
     "subject": "Patient/2",
-    "actualPeriod.start": "2021-04-01 18:00:00",
+    "actualPeriod.start": "2021-04-01T18:00:00-0300",
     "actualPeriod.end": "2021-04-10",
     "admission.dischargeDisposition.code": "https://snomed.info/sct|371827001",
     "admission.dischargeDisposition.text": "Patient discharged alive (finding)",
@@ -136,7 +136,9 @@ def test_load_data_one_to_one_single_row():
     )
 
     assert df is not None
-    Encounter.ingest_to_flat(df, "encounter_ingestion_single")
+    Encounter.ingest_to_flat(
+        df, "encounter_ingestion_single", "%Y-%m-%d", "Brazil/East"
+    )
 
     assert_frame_equal(
         pd.read_parquet("encounter_ingestion_single.parquet"),
@@ -294,12 +296,12 @@ ENCOUNTER_SINGLE_ROW_MULTI = {
     "id": ["10", "11", "12", "13"],
     "actualPeriod.start": [
         "2020-05-01",
-        "2021-04-01 18:00:00",
-        "2021-05-10 17:30:00",
-        "2022-06-15 21:00:00",
+        "2021-04-01T18:00:00-0300",
+        "2021-05-10T17:30:00-0300",
+        "2022-06-15T21:00:00-0300",
     ],
     "actualPeriod.end": [
-        "2020-05-01",
+        "2020-05-01",  # don't want this
         "2021-04-10",
         "2021-05-15",
         "2022-06-20",
@@ -340,7 +342,7 @@ def test_load_data_one_to_one_multi_row():
     )
 
     assert df is not None
-    Encounter.ingest_to_flat(df, "encounter_ingestion_multi")
+    Encounter.ingest_to_flat(df, "encounter_ingestion_multi", "%Y-%m-%d", "Brazil/East")
 
     assert_frame_equal(
         pd.read_parquet("encounter_ingestion_multi.parquet"),
@@ -432,7 +434,9 @@ def test_load_data_one_to_many_multi_row():
     )
 
     assert df is not None
-    Observation.ingest_to_flat(df.dropna(), "observation_ingestion")
+    Observation.ingest_to_flat(
+        df.dropna(), "observation_ingestion", "%Y-%m-%d", "Brazil/East"
+    )
 
     full_df = pd.read_parquet("observation_ingestion.parquet")
 
@@ -461,6 +465,8 @@ def test_convert_data_to_flat_local_mapping():
         "tests/dummy_data/combined_dummy_data.csv",
         mapping_files_types=(mappings, resource_types),
         folder_name=output_folder,
+        date_format="%Y-%m-%d",
+        timezone="Brazil/East",
     )
 
     encounter_df = pd.read_parquet("tests/ingestion_output/encounter.parquet")


### PR DESCRIPTION
Adds arguments to `convert_data_to_flat` function for the current date format and timezone.

On ingestion dates/datetimes are converted to the ISO8601 standard.

FHIRflat natively has validation check that date format matches YYYY-MM-DD, but doesn't check for a timezone if a time is provided (https://github.com/nazrulworld/fhir.resources/blob/3f61a5e7963657ed354e2d02b938c62569583299/fhir/resources/fhirtypes.py#L518).

Chose not to put datetime options in google sheets mapping files to keep files streamlined.

Fixes #33, related to #32