### PR TITLE
Backbone element tracking

### DIFF
--- a/fhirflat/resources/base.py
+++ b/fhirflat/resources/base.py
@@ -115,7 +115,12 @@ class FHIRFlatBase(_DomainResource):
                         continue
                     else:
                         backbone_list = []
-                        for i in range(len(next(iter(condensed_dict.values())))):
+                        # assert all lists are the same length - if not different parts
+                        # of the backbone element may be incorrectly grouped together
+                        assert len(set(map(len, condensed_dict.values()))) == 1
+
+                        # iterate through and split the element into individual levels
+                        for i in range(max(len(x) for x in condensed_dict.values())):
                             first_item = {
                                 k.lstrip(b_e + "."): v[i]
                                 for k, v in condensed_dict.items()
@@ -271,6 +276,7 @@ class FHIRFlatBase(_DomainResource):
 
         if filename:
             flat_df.to_parquet(filename)
+            return None
         else:
             assert flat_df.shape[0] == 1
             return flat_df.loc[0]

--- a/tests/dummy_data/data_multirow_encounter_freetext.csv
+++ b/tests/dummy_data/data_multirow_encounter_freetext.csv
@@ -1,0 +1,3 @@
+subjid,dates_enrolment,dates_adm,dates_admdate,dates_admtime,outco_denguediag,outco_denguediag_main,outco_denguediag_class,outco_secondiag,outco_secondiag_oth,outco_date,outco_outcome
+1,2021-10-22,1,2021-10-20,18:40,,,,,,,
+1,,,,,1,,3,1,RTI,2021-10-23,1.0

--- a/tests/dummy_data/data_multirow_encounter_freetext_maindiag.csv
+++ b/tests/dummy_data/data_multirow_encounter_freetext_maindiag.csv
@@ -1,0 +1,3 @@
+subjid,dates_enrolment,dates_adm,dates_admdate,dates_admtime,outco_denguediag,outco_denguediag_main,outco_denguediag_class,outco_secondiag,outco_secondiag_oth,outco_date,outco_outcome
+1,2021-10-22,1,2021-10-20,18:40,,,,,,,
+1,,,,,0,sepsis,2,,,2021-10-23,1.0

--- a/tests/dummy_data/data_multirow_encounter_freetext_secdiag.csv
+++ b/tests/dummy_data/data_multirow_encounter_freetext_secdiag.csv
@@ -1,0 +1,3 @@
+subjid,dates_enrolment,dates_adm,dates_admdate,dates_admtime,outco_denguediag,outco_denguediag_main,outco_denguediag_class,outco_secondiag,outco_secondiag_oth,outco_date,outco_outcome
+1,2021-10-22,1,2021-10-20,18:40,,,,,,,
+1,,,,,99,,,1,secondary Dengue,2021-10-23,1.0

--- a/tests/dummy_data/encounter_dummy_mapping.csv
+++ b/tests/dummy_data/encounter_dummy_mapping.csv
@@ -9,7 +9,7 @@ dates_admdate,,,,,,,,,,<FIELD>+<dates_admtime>,,,,,,,,,,
 dates_admtime,,,,,,,,,,<dates_admdate>+<FIELD>,,,,,,,,,,
 outco_denguediag,"1, Yes",,,,,,,,,,,https://snomed.info/sct,38362002,Dengue (disorder),https://snomed.info/sct,89100005,Final diagnosis (discharge) (contextual qualifier) (qualifier value),,,
 ,"0, No",,,,,,,,,,,,,,,,,,,
-,"99, Unknown",,,,,,,,,,,https://snomed.info/sct,261665006,Unknown (qualifier value),,,,,,
+,"99, Unknown",,,,,,,,,,,https://snomed.info/sct,261665006,Unknown (qualifier value),https://snomed.info/sct,89100005,Final diagnosis (discharge) (contextual qualifier) (qualifier value),,,
 outco_date,,,,,,,,,,,<FIELD>,,,,,,,,,
 outco_outcome,"1, Discharged alive",,,,,,,,,,,,,,,,,https://snomed.info/sct,371827001,Patient discharged alive (finding)
 ,"2, Still hospitalised",,,,,,,,,,,,,,,,,https://snomed.info/sct,32485007,Hospital admission (procedure)

--- a/tests/test_flat2fhir_units.py
+++ b/tests/test_flat2fhir_units.py
@@ -79,6 +79,61 @@ def test_create_codeable_concept(data_groups, expected):
 
 
 @pytest.mark.parametrize(
+    "data_groups, expected",
+    [
+        (
+            (
+                {
+                    "code.code": ["1234"],
+                    "code.system": ["http://loinc.org"],
+                    "code.text": ["Test"],
+                },
+                "code",
+            ),
+            {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "1234",
+                        "display": "Test",
+                    }
+                ]
+            },
+        ),
+        (
+            (
+                {
+                    "code.code": ["1234", "5678"],
+                    "code.system": ["http://loinc.org", "http://snomed.info/sct"],
+                    "code.text": ["Test", "Snomed Test"],
+                },
+                "code",
+            ),
+            {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "1234",
+                        "display": "Test",
+                    },
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "5678",
+                        "display": "Snomed Test",
+                    },
+                ]
+            },
+        ),
+    ],
+)
+def test_create_codeable_concept_ingestion(data_groups, expected):
+    data, groups = data_groups
+    result = f2f.create_codeable_concept(data, groups)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
     "data_class, expected",
     [
         (


### PR DESCRIPTION
Forces list elements to be padded with `None` during data ingestion to keep them the same length. When backbone elements are created, the lists are the same length to keep correct linkages between different sections.

Fixes #42 