### PR TITLE
Split ingestion pipeline

### DIFF
--- a/fhirflat/fhir2flat.py
+++ b/fhirflat/fhir2flat.py
@@ -127,7 +127,7 @@ def condenseCoding(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
     If a "text" field has already been provided, this overrides the display.
     """
 
-    def expand(
+    def condense(
         row: pd.Series, column_name: str, text_present: bool = False
     ) -> pd.Series:
         codes = row[column_name]
@@ -148,7 +148,7 @@ def condenseCoding(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
     if column_name.removesuffix(".coding") + ".text" in df.columns:
         text_present = True
 
-    df = df.apply(lambda x: expand(x, column_name, text_present), axis=1)
+    df = df.apply(lambda x: condense(x, column_name, text_present), axis=1)
 
     if not text_present:
         df.insert(

--- a/fhirflat/fhir2flat.py
+++ b/fhirflat/fhir2flat.py
@@ -115,14 +115,14 @@ def implode(df: pd.DataFrame) -> pd.DataFrame:
     return df.groupby(df.index).agg(single_or_list)
 
 
-def expandCoding(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
+def condenseCoding(df: pd.DataFrame, column_name: str) -> pd.DataFrame:
     """
     Turns a column containing a list of dictionaries with coding information into
     2 columns containing a list of strings with the coding information, and the text.
 
     [ {"system": "http://loinc.org", "code": "1234", "display": "Test"} ]
     becomes
-    [ "http://loinc.org/1234" ], ["Test"]
+    [ "http://loinc.org|1234" ], ["Test"]
 
     If a "text" field has already been provided, this overrides the display.
     """
@@ -291,7 +291,7 @@ def fhir2flat(resource: FHIRFlatBase, lists: list | None = None) -> pd.DataFrame
 
     # expand all instances of the "coding" list
     for coding in df.columns[df.columns.str.endswith("coding")]:
-        df = expandCoding(df, coding)
+        df = condenseCoding(df, coding)
 
     # condense all references
     for reference in df.columns[df.columns.str.endswith("reference")]:

--- a/fhirflat/flat2fhir.py
+++ b/fhirflat/flat2fhir.py
@@ -216,6 +216,7 @@ def expand_concepts(data: dict[str, str], data_class: type[_DomainResource]) -> 
     Combines columns containing flattened FHIR concepts back into
     JSON-like structures.
     """
+
     groups = group_keys(data.keys())
     group_classes = {}
 

--- a/fhirflat/ingest.py
+++ b/fhirflat/ingest.py
@@ -518,6 +518,16 @@ def convert_data_to_flat(
             os.path.join(folder_name, resource.__name__.lower()),
         )
 
+        # flat_nonvalidated = resource.ingest_to_flat(
+        #     df,
+        #     # os.path.join(folder_name, resource.__name__.lower()),
+        # )
+
+        # valid_flat, errors = resource.validate_flat(flat_nonvalidated)
+        # valid_flat.to_parquet(
+        #     f"{os.path.join(folder_name, resource.__name__.lower())}.parquet"
+        # )
+
         end_time = timeit.default_timer()
         total_time = end_time - start_time
         print(

--- a/fhirflat/ingest.py
+++ b/fhirflat/ingest.py
@@ -431,6 +431,7 @@ def convert_data_to_flat(
     mapping_files_types: tuple[dict, dict] | None = None,
     sheet_id: str | None = None,
     subject_id="subjid",
+    validate: bool = True,
 ):
     """
     Takes raw clinical data (currently assumed to be a one-row-per-patient format like
@@ -513,20 +514,19 @@ def convert_data_to_flat(
         else:
             raise ValueError(f"Unknown mapping type {t}")
 
-        errors = resource.ingest_to_flat(
-            df,
-            os.path.join(folder_name, resource.__name__.lower()),
-        )
+        flat_nonvalidated = resource.ingest_to_flat(df)
 
-        # flat_nonvalidated = resource.ingest_to_flat(
-        #     df,
-        #     # os.path.join(folder_name, resource.__name__.lower()),
-        # )
+        if validate:
+            valid_flat, errors = resource.validate_fhirflat(flat_nonvalidated)
 
-        # valid_flat, errors = resource.validate_flat(flat_nonvalidated)
-        # valid_flat.to_parquet(
-        #     f"{os.path.join(folder_name, resource.__name__.lower())}.parquet"
-        # )
+            valid_flat.to_parquet(
+                f"{os.path.join(folder_name, resource.__name__.lower())}.parquet"
+            )
+        else:
+            errors = None
+            flat_nonvalidated.to_parquet(
+                f"{os.path.join(folder_name, resource.__name__.lower())}.parquet"
+            )
 
         end_time = timeit.default_timer()
         total_time = end_time - start_time

--- a/fhirflat/resources/base.py
+++ b/fhirflat/resources/base.py
@@ -273,14 +273,16 @@ class FHIRFlatBase(_DomainResource):
                 )
             flat_df.drop(columns=system_columns, inplace=True)
 
-            list_cols = [
-                col
-                for col in flat_df.columns
-                if flat_df[col].apply(lambda x: isinstance(x, list)).any()
+            potential_dense_cols = [
+                x for x in cls.backbone_elements.keys() if x in flat_df.columns
             ]
-            list_lengths = [len(flat_df[x].dropna().iloc[0]) for x in list_cols]
+            list_lengths = [
+                len(flat_df[x].dropna().iloc[0]) for x in potential_dense_cols
+            ]
             long_list_cols = [
-                x for x, y in zip(list_cols, list_lengths, strict=True) if y > 1
+                x
+                for x, y in zip(potential_dense_cols, list_lengths, strict=True)
+                if y > 1
             ]
 
             if long_list_cols:

--- a/tests/test_condition_resource.py
+++ b/tests/test_condition_resource.py
@@ -106,28 +106,26 @@ CONDITION_DICT_INPUT = {
 }
 
 CONDITION_FLAT = {
-    "resourceType": ["Condition"],
+    "resourceType": "Condition",
     "extension.presenceAbsence.code": ["http://snomed.info/sct|410605003"],
     "extension.presenceAbsence.text": ["Present"],
-    "extension.prespecifiedQuery": [True],
+    "extension.prespecifiedQuery": True,
     "category.code": [
-        [
-            "http://snomed.info/sct|55607006",
-            "http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item",  # noqa: E501
-        ]
+        "http://snomed.info/sct|55607006",
+        "http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item",  # noqa: E501
     ],
-    "category.text": [["Problem", None]],
+    "category.text": ["Problem", None],
     "bodySite.code": ["http://snomed.info/sct|38266002"],
-    "bodySite.text": ["whole body"],
-    "onsetDateTime": [datetime.date(2013, 4, 2)],
-    "abatementString": ["around April 9, 2013"],
-    "recordedDate": [datetime.date(2013, 4, 4)],
+    "bodySite.text": "whole body",
+    "onsetDateTime": datetime.date(2013, 4, 2),
+    "abatementString": "around April 9, 2013",
+    "recordedDate": datetime.date(2013, 4, 4),
     "severity.code": ["http://snomed.info/sct|255604002"],
     "severity.text": ["Mild"],
     "code.code": ["http://snomed.info/sct|386661006"],
-    "code.text": ["Fever"],
-    "subject": ["Patient/f201"],
-    "encounter": ["Encounter/f201"],
+    "code.text": "Fever",
+    "subject": "Patient/f201",
+    "encounter": "Encounter/f201",
 }
 
 CONDITION_DICT_OUT = {
@@ -209,11 +207,12 @@ def test_condition_to_flat():
 
     fever.to_flat("test_condition.parquet")
 
-    assert_frame_equal(
-        pd.read_parquet("test_condition.parquet"),
-        pd.DataFrame(CONDITION_FLAT),
-        check_like=True,
-    )
+    fever_flat = pd.read_parquet("test_condition.parquet")
+    expected = pd.DataFrame([CONDITION_FLAT], index=[0])
+    expected = expected.reindex(sorted(expected.columns), axis=1)
+    # v, e = Condition.validate_fhirflat(expected)
+
+    assert_frame_equal(fever_flat, expected)
     os.remove("test_condition.parquet")
 
 

--- a/tests/test_fhir2flat_units.py
+++ b/tests/test_fhir2flat_units.py
@@ -118,12 +118,12 @@ def test_explode_and_flatten_no_multiples(data_lists, expected):
         ),
     ],
 )
-def test_expandCoding(data, expected):
+def test_condenseCoding(data, expected):
     # Create a mock DataFrame
     df = pd.DataFrame(data)
 
     # Call the function
-    result = f2f.expandCoding(df, "code.coding")
+    result = f2f.condenseCoding(df, "code.coding")
 
     # Check the result
     expected = pd.DataFrame(expected)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1044,14 +1044,94 @@ def test_validate_fhirflat_single_resource_errors():
     flat_df = Encounter.ingest_to_flat(df)
     with pytest.raises(ValidationError, match="invalid datetime format"):
         _, _ = Encounter.validate_fhirflat(flat_df)
-    # assert len(error_df) == 1
-    # assert (
-    #     repr(error_df["validation_error"][0].errors())
-    #     == "[{'loc': ('actualPeriod', 'start'), 'msg': 'invalid datetime format', 'type': 'value_error.datetime'}]"  # noqa: E501
-    # )
 
 
-# TODO: add test for validate_fhirflat with multiple resources
+def test_validate_fhirflat_multi_resource_errors():
+    df = pd.DataFrame(
+        {
+            "subjid": [1, 2],
+            "flat_dict": [
+                {
+                    "subject": "Patient/1",
+                    "id": 11,
+                    "actualPeriod.start": "2021-04-01",
+                    "actualPeriod.end": "2021-04-10",
+                    "extension.timingPhase.system": "https://snomed.info/sct",
+                    "extension.timingPhase.code": 278307001.0,
+                    "extension.timingPhase.text": "On admission (qualifier value)",
+                    "class.system": "https://snomed.info/sct",
+                    "class.code": 32485007.0,
+                    "class.text": "Hospital admission (procedure)",
+                    "diagnosis.condition.concept.system": [
+                        "https://snomed.info/sct",
+                        "https://snomed.info/sct",
+                    ],
+                    "diagnosis.condition.concept.code": [38362002.0, 722863008.0],
+                    "diagnosis.condition.concept.text": [
+                        "Dengue (disorder)",
+                        "Dengue with warning signs (disorder)",
+                    ],
+                    "diagnosis.use.system": [
+                        "https://snomed.info/sct",
+                        "https://snomed.info/sct",
+                    ],
+                    "diagnosis.use.code": [89100005.0, 89100005.0],
+                    "diagnosis.use.text": [
+                        "Final diagnosis (discharge) (contextual qualifier) (qualifier value)",  # noqa: E501
+                        "Final diagnosis (discharge) (contextual qualifier) (qualifier value)",  # noqa: E501
+                    ],
+                    "admission.dischargeDisposition.system": "https://snomed.info/sct",
+                    "admission.dischargeDisposition.code": 371827001.0,
+                    "admission.dischargeDisposition.text": "Patient discharged alive (finding)",  # noqa: E501
+                },
+                {
+                    "subject": "Patient/2",
+                    "id": 12,
+                    "actualPeriod.start": ["2021-04-01", None],
+                    "actualPeriod.end": [None, "2021-04-10"],
+                    "extension.timingPhase.system": "https://snomed.info/sct",
+                    "extension.timingPhase.code": 278307001.0,
+                    "extension.timingPhase.text": "On admission (qualifier value)",
+                    "class.system": "https://snomed.info/sct",
+                    "class.code": 32485007.0,
+                    "class.text": "Hospital admission (procedure)",
+                    "diagnosis.condition.concept.system": [
+                        "https://snomed.info/sct",
+                        "https://snomed.info/sct",
+                    ],
+                    "diagnosis.condition.concept.code": [38362002.0, 722863008.0],
+                    "diagnosis.condition.concept.text": [
+                        "Dengue (disorder)",
+                        "Dengue with warning signs (disorder)",
+                    ],
+                    "diagnosis.use.system": [
+                        "https://snomed.info/sct",
+                        "https://snomed.info/sct",
+                    ],
+                    "diagnosis.use.code": [89100005.0, 89100005.0],
+                    "diagnosis.use.text": [
+                        "Final diagnosis (discharge) (contextual qualifier) (qualifier value)",  # noqa: E501
+                        "Final diagnosis (discharge) (contextual qualifier) (qualifier value)",  # noqa: E501
+                    ],
+                    "admission.dischargeDisposition.system": "https://snomed.info/sct",
+                    "admission.dischargeDisposition.code": 371827001.0,
+                    "admission.dischargeDisposition.text": "Patient discharged alive (finding)",  # noqa: E501
+                },
+            ],
+        },
+    )
+    flat_df = Encounter.ingest_to_flat(df)
+
+    assert "diagnosis_dense" in flat_df.columns
+
+    valid, errors = Encounter.validate_fhirflat(flat_df)
+
+    assert len(valid) == 1
+    assert len(errors) == 1
+    assert (
+        repr(errors["validation_error"][1].errors())
+        == "[{'loc': ('actualPeriod', 'end'), 'msg': 'invalid type; expected datetime, string, bytes, int or float', 'type': 'type_error'}, {'loc': ('actualPeriod', 'start'), 'msg': 'invalid type; expected datetime, string, bytes, int or float', 'type': 'type_error'}]"  # noqa: E501
+    )
 
 
 def test_convert_data_to_flat_local_mapping_errors():


### PR DESCRIPTION
Splits the ingestion pipeline into two parts; fhirflat file creation and validation.

The initial file creation doesn't pack/unpack any pydantic FHIR resource classes, while validation tries to create resources but doesn't then convert them back into fhirflat files. Together, this provides a significant speedup even when running both file creation and validation together to mimic the previous `ingest_to_flat` behaviour.

Previous speeds on a sample dataset:
```
Patient took 1.19 seconds to convert 67 rows.
Encounter took 1.31 seconds to convert 67 rows.
Observation took 6.85 seconds to convert 2194 rows.
Condition took 5.99 seconds to convert 461 rows.
```

New speeds doing ingestion + validation together (no parallel processing implemented):
```
Patient took 0.78 seconds to convert 67 rows. 
Encounter took 0.68 seconds to convert 67 rows. 
2 resources not created due to validation errors. Errors saved to encounter_errors.csv
Observation took 1.61 seconds to convert 2194 rows. 
Condition took 0.78 seconds to convert 461 rows. 
```

TODO: Add an extra CLI option `validate` which will validate previously created FHIRflat files. Interface to `FHIRFlatBase.validate_fhirflat()`.

Fixes #54 