### PR TITLE
Speed: take 2

### DIFF
--- a/fhirflat/ingest.py
+++ b/fhirflat/ingest.py
@@ -510,7 +510,7 @@ def convert_data_to_flat(
         resource, data, map_file, t, subject_id, date_format, timezone
     ):
         start_time = timeit.default_timer()
-        o2o = True if t == "one-to-one" else False
+        o2o = t == "one-to-one"
 
         if t in ["one-to-one", "one-to-many"]:
             df = create_dictionary(
@@ -579,32 +579,19 @@ def convert_data_to_flat(
                 f"Errors saved to {resource.__name__.lower()}_errors.csv"
             )
 
-    if parallel:
-        total_t = timeit.default_timer()
-        _ = Parallel(n_jobs=-1)(
-            delayed(convert_resource)(
-                resource,
-                data,
-                map_file,
-                types[resource.__name__],
-                subject_id,
-                date_format,
-                timezone,
-            )
-            for resource, map_file in mappings.items()
+    total_t = timeit.default_timer()
+    _ = Parallel(n_jobs=-1 if parallel else 1)(
+        delayed(convert_resource)(
+            resource,
+            data,
+            map_file,
+            types[resource.__name__],
+            subject_id,
+            date_format,
+            timezone,
         )
-    else:
-        total_t = timeit.default_timer()
-        for resource, map_file in mappings.items():
-            convert_resource(
-                resource,
-                data,
-                map_file,
-                types[resource.__name__],
-                subject_id,
-                date_format,
-                timezone,
-            )
+        for resource, map_file in mappings.items()
+    )
 
     print(f"Total time: {timeit.default_timer() - total_t}")
 

--- a/fhirflat/ingest.py
+++ b/fhirflat/ingest.py
@@ -451,31 +451,31 @@ def convert_data_to_flat(
 
     Parameters
     ----------
-    data: str
+    data
         The path to the raw clinical data file.
-    date_format: str
+    date_format
         The format of the dates in the data file. E.g. "%Y-%m-%d"
-    timezone: str
+    timezone
         The timezone of the dates in the data file. E.g. "Europe/London"
-    folder_name: str
+    folder_name
         The name of the folder to store the FHIRflat files.
-    mapping_files_types: tuple[dict, dict] | None
+    mapping_files_types
         A tuple containing two dictionaries, one with the mapping files for each
         resource type and one with the mapping type (either one-to-one or one-to-many)
         for each resource type.
-    sheet_id: str | None
+    sheet_id
         The Google Sheet ID containing the mapping files. The first sheet must contain
         the mapping types - one column listing the resource name, and another describing
         whether the mapping is one-to-one or one-to-many. The subsequent sheets must
         be named by resource, and contain the mapping for that resource.
-    subject_id: str
+    subject_id
         The name of the column containing the subject ID in the data file.
-    validate: bool
+    validate
         Whether to validate the FHIRflat files after creation.
-    compress_format: optional str
+    compress_format
         If the output folder should be zipped, and if so with what format.
-    parallel: bool
-        Whether to parallelize the conversion process.
+    parallel
+        Whether to parallelize the data conversion over different resources.
     """
 
     if not mapping_files_types and not sheet_id:
@@ -711,6 +711,13 @@ def main():
         choices=["zip", "tar", "gztar", "bztar", "xztar"],
     )
 
+    parser.add_argument(
+        "-p",
+        "--parallel",
+        help="Parallelize the data conversion over different reosurces",
+        action="store_true",
+    )
+
     args = parser.parse_args()
 
     convert_data_to_flat(
@@ -722,6 +729,7 @@ def main():
         subject_id=args.subject_id,
         validate=args.validate,
         compress_format=args.compress,
+        parallel=args.parallel,
     )
 
 

--- a/fhirflat/resources/base.py
+++ b/fhirflat/resources/base.py
@@ -119,9 +119,10 @@ class FHIRFlatBase(_DomainResource):
 
         flat_df = df.copy()
 
-        flat_df["fhir"] = flat_df.apply(
+        fhir_json = flat_df.apply(
             lambda row: row.to_json(date_format="iso", date_unit="s"), axis=1
-        ).apply(lambda x: cls.create_fhir_resource(x))
+        )
+        flat_df["fhir"] = fhir_json.apply(lambda x: cls.create_fhir_resource(x))
 
         if len(flat_df) == 1 and return_frames is False:
             resource = flat_df["fhir"].iloc[0]

--- a/fhirflat/resources/condition.py
+++ b/fhirflat/resources/condition.py
@@ -4,6 +4,7 @@ from typing import ClassVar, TypeAlias, Union
 
 from fhir.resources import fhirtypes
 from fhir.resources.condition import Condition as _Condition
+from fhir.resources.condition import ConditionParticipant, ConditionStage
 from pydantic.v1 import Field, validator
 
 from .base import FHIRFlatBase
@@ -45,6 +46,11 @@ class Condition(_Condition, FHIRFlatBase):
         "evidence",
         "note",
         "participant",
+    }
+
+    backbone_elements: ClassVar[dict] = {
+        "participant": ConditionParticipant,
+        "stage": ConditionStage,
     }
 
     # required attributes that are not present in the FHIRflat representation

--- a/fhirflat/resources/immunization.py
+++ b/fhirflat/resources/immunization.py
@@ -4,6 +4,12 @@ from typing import ClassVar, TypeAlias, Union
 
 from fhir.resources import fhirtypes
 from fhir.resources.immunization import Immunization as _Immunization
+from fhir.resources.immunization import (
+    ImmunizationPerformer,
+    ImmunizationProgramEligibility,
+    ImmunizationProtocolApplied,
+    ImmunizationReaction,
+)
 from pydantic.v1 import Field, validator
 
 from .base import FHIRFlatBase
@@ -53,6 +59,13 @@ class Immunization(_Immunization, FHIRFlatBase):
 
     # required attributes that are not present in the FHIRflat representation
     flat_defaults: ClassVar[list[str]] = [*FHIRFlatBase.flat_defaults, "status"]
+
+    backbone_elements: ClassVar[dict] = {
+        "performer": ImmunizationPerformer,
+        "programEligibility": ImmunizationProgramEligibility,
+        "reaction": ImmunizationReaction,
+        "protocolApplied": ImmunizationProtocolApplied,
+    }
 
     @validator("extension")
     def validate_extension_contents(cls, extensions):

--- a/fhirflat/resources/location.py
+++ b/fhirflat/resources/location.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import ClassVar, TypeAlias
 
 from fhir.resources.location import Location as _Location
+from fhir.resources.location import LocationPosition
 
 from .base import FHIRFlatBase
 
@@ -18,6 +19,8 @@ class Location(_Location, FHIRFlatBase):
         "contact",  # phone numbers, addresses,
         "hoursOfOperation",
     }
+
+    backbone_elements: ClassVar[dict] = {"position": LocationPosition}
 
     @classmethod
     def cleanup(cls, data: dict) -> dict:

--- a/fhirflat/resources/medicationadministration.py
+++ b/fhirflat/resources/medicationadministration.py
@@ -5,6 +5,10 @@ from typing import ClassVar, TypeAlias
 from fhir.resources.medicationadministration import (
     MedicationAdministration as _MedicationAdministration,
 )
+from fhir.resources.medicationadministration import (
+    MedicationAdministrationDosage,
+    MedicationAdministrationPerformer,
+)
 
 from .base import FHIRFlatBase
 
@@ -23,6 +27,11 @@ class MedicationAdministration(_MedicationAdministration, FHIRFlatBase):
 
     # required attributes that are not present in the FHIRflat representation
     flat_defaults: ClassVar[list[str]] = [*FHIRFlatBase.flat_defaults, "status"]
+
+    backbone_elements: ClassVar[dict] = {
+        "performer": MedicationAdministrationPerformer,
+        "dosage": MedicationAdministrationDosage,
+    }
 
     @classmethod
     def cleanup(cls, data: dict) -> dict:

--- a/fhirflat/resources/medicationstatement.py
+++ b/fhirflat/resources/medicationstatement.py
@@ -5,6 +5,9 @@ from typing import ClassVar, TypeAlias
 from fhir.resources.medicationstatement import (
     MedicationStatement as _MedicationStatement,
 )
+from fhir.resources.medicationstatement import (
+    MedicationStatementAdherence,
+)
 
 from .base import FHIRFlatBase
 
@@ -22,6 +25,8 @@ class MedicationStatement(_MedicationStatement, FHIRFlatBase):
 
     # required attributes that are not present in the FHIRflat representation
     flat_defaults: ClassVar[list[str]] = [*FHIRFlatBase.flat_defaults, "status"]
+
+    backbone_elements: ClassVar[dict] = {"adherence": MedicationStatementAdherence}
 
     @classmethod
     def cleanup(cls, data: dict) -> dict:

--- a/fhirflat/resources/observation.py
+++ b/fhirflat/resources/observation.py
@@ -4,7 +4,13 @@ from typing import ClassVar, TypeAlias, Union
 
 from fhir.resources import fhirtypes
 from fhir.resources.observation import Observation as _Observation
-from fhir.resources.observation import ObservationComponent as _ObservationComponent
+from fhir.resources.observation import (
+    ObservationComponent as _ObservationComponent,
+)
+from fhir.resources.observation import (
+    ObservationReferenceRange,
+    ObservationTriggeredBy,
+)
 from pydantic.v1 import Field, validator
 
 from .base import FHIRFlatBase
@@ -79,6 +85,12 @@ class Observation(_Observation, FHIRFlatBase):
 
     # required attributes that are not present in the FHIRflat representation
     flat_defaults: ClassVar[list[str]] = [*FHIRFlatBase.flat_defaults, "status"]
+
+    backbone_elements: ClassVar[dict] = {
+        "triggeredBy": ObservationTriggeredBy,
+        "referenceRange": ObservationReferenceRange,
+        "component": _ObservationComponent,
+    }
 
     @validator("extension")
     def validate_extension_contents(cls, extensions):

--- a/fhirflat/resources/organization.py
+++ b/fhirflat/resources/organization.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import ClassVar, TypeAlias
 
-from fhir.resources.organization import Organization as _Organization
+from fhir.resources.organization import (
+    Organization as _Organization,
+)
+from fhir.resources.organization import (
+    OrganizationQualification,
+)
 
 from .base import FHIRFlatBase
 
@@ -17,6 +22,8 @@ class Organization(_Organization, FHIRFlatBase):
         "active",
         "contact",  # phone numbers, addresses
     }
+
+    backbone_elements: ClassVar[dict] = {"qualification": OrganizationQualification}
 
     @classmethod
     def cleanup(cls, data: dict) -> dict:

--- a/fhirflat/resources/patient.py
+++ b/fhirflat/resources/patient.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from typing import ClassVar, TypeAlias, Union
 
 from fhir.resources import fhirtypes
-from fhir.resources.patient import Patient as _Patient
+from fhir.resources.patient import (
+    Patient as _Patient,
+)
+from fhir.resources.patient import (
+    PatientCommunication,
+    PatientContact,
+    PatientLink,
+)
 from pydantic.v1 import Field, validator
 
 from .base import FHIRFlatBase
@@ -41,6 +48,12 @@ class Patient(_Patient, FHIRFlatBase):
         "contact",
         "communication",
         "link",
+    }
+
+    backbone_elements: ClassVar[dict] = {
+        "contact": PatientContact,
+        "communication": PatientCommunication,
+        "link": PatientLink,
     }
 
     @validator("extension")

--- a/fhirflat/resources/procedure.py
+++ b/fhirflat/resources/procedure.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from typing import ClassVar, TypeAlias, Union
 
 from fhir.resources import fhirtypes
-from fhir.resources.procedure import Procedure as _Procedure
+from fhir.resources.procedure import (
+    Procedure as _Procedure,
+)
+from fhir.resources.procedure import (
+    ProcedureFocalDevice,
+    ProcedurePerformer,
+)
 from pydantic.v1 import Field, validator
 
 from .base import FHIRFlatBase
@@ -62,6 +68,11 @@ class Procedure(_Procedure, FHIRFlatBase):
 
     # required attributes that are not present in the FHIRflat representation
     flat_defaults: ClassVar[list[str]] = [*FHIRFlatBase.flat_defaults, "status"]
+
+    backbone_elements: ClassVar[dict] = {
+        "performer": ProcedurePerformer,
+        "focalDevice": ProcedureFocalDevice,
+    }
 
     @validator("extension")
     def validate_extension_contents(cls, extensions):

--- a/fhirflat/resources/researchsubject.py
+++ b/fhirflat/resources/researchsubject.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import ClassVar, TypeAlias
 
-from fhir.resources.researchsubject import ResearchSubject as _ResearchSubject
+from fhir.resources.researchsubject import (
+    ResearchSubject as _ResearchSubject,
+)
+from fhir.resources.researchsubject import (
+    ResearchSubjectProgress,
+)
 
 from .base import FHIRFlatBase
 
@@ -18,6 +23,8 @@ class ResearchSubject(_ResearchSubject, FHIRFlatBase):
 
     # required attributes that are not present in the FHIRflat representation
     flat_defaults: ClassVar[list[str]] = [*FHIRFlatBase.flat_defaults, "status"]
+
+    backbone_elements: ClassVar[dict] = {"progress": ResearchSubjectProgress}
 
     @classmethod
     def cleanup(cls, data: dict) -> dict:

--- a/fhirflat/resources/specimen.py
+++ b/fhirflat/resources/specimen.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from typing import ClassVar, TypeAlias
 
-from fhir.resources.specimen import Specimen as _Specimen
+from fhir.resources.specimen import (
+    Specimen as _Specimen,
+)
+from fhir.resources.specimen import (
+    SpecimenCollection,
+    SpecimenContainer,
+    SpecimenFeature,
+    SpecimenProcessing,
+)
 
 from fhirflat.flat2fhir import expand_concepts
 
@@ -19,6 +27,13 @@ class Specimen(_Specimen, FHIRFlatBase):
         "accessionIdentifier",
         "status",
         "note",
+    }
+
+    backbone_elements: ClassVar[dict] = {
+        "feature": SpecimenFeature,
+        "collection": SpecimenCollection,
+        "processing": SpecimenProcessing,
+        "container": SpecimenContainer,
     }
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,13 @@ dependencies = [
     "fhir.resources==7.1.0",
     "numpy==1.26.4",
     "orjson==3.9.13",
-    "pandas>=2.2.0",
+    "pandas[performance]>=2.2.0",
     "pyarrow==15.0.0",
     "pydantic==2.6.1",
     "pydantic_core==2.16.2",
     "tzdata",
     "python-dateutil",
+    "joblib",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,7 +3,6 @@ import fhirflat
 import pandas as pd
 import pytest
 from pydantic.v1 import ValidationError
-from pathlib import Path
 
 
 def test_flat_fields():

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1038,6 +1038,29 @@ def test_convert_data_to_flat_local_mapping():
     shutil.rmtree(output_folder)
 
 
+def test_convert_data_to_flat_local_mapping_parallel():
+    output_folder = "tests/ingestion_output"
+    mappings = {
+        Encounter: "tests/dummy_data/encounter_dummy_mapping.csv",
+        Observation: "tests/dummy_data/observation_dummy_mapping.csv",
+    }
+    resource_types = {"Encounter": "one-to-one", "Observation": "one-to-many"}
+
+    convert_data_to_flat(
+        "tests/dummy_data/combined_dummy_data.csv",
+        folder_name=output_folder,
+        date_format="%Y-%m-%d",
+        timezone="Brazil/East",
+        mapping_files_types=(mappings, resource_types),
+        parallel=True,
+    )
+
+    assert os.path.exists("tests/ingestion_output/encounter.parquet")
+    assert os.path.exists("tests/ingestion_output/observation.parquet")
+
+    shutil.rmtree(output_folder)
+
+
 def test_convert_data_to_flat_local_mapping_zipped():
     output_folder = "tests/ingestion_output"
     mappings = {


### PR DESCRIPTION
Different approach to increasing ingestion speed.

This PR uses `joblib` to parallelise the ingestion across resources.
The current two time sinks are:
 * reading in the data & mapping files (not much we can do about that)
 * the 'create_dictionary' function, likely because of all the iterating over row/columns using `apply` going on.

Without parallelisation, current time is:
```
Patient took 0.88 seconds to convert 67 rows. 
Encounter took 0.74 seconds to convert 67 rows. 
2 resources not created due to validation errors. Errors saved to encounter_errors.csv
Observation took 1.81 seconds to convert 2194 rows. 
Condition took 1.07 seconds to convert 461 rows. 
Total time: 4.4922334590228274
```

With parallelisation one, the speed up is:
```
Patient took 0.78 seconds to convert 67 rows. 
Encounter took 0.73 seconds to convert 67 rows. 
2 resources not created due to validation errors. Errors saved to encounter_errors.csv
Observation took 1.71 seconds to convert 2194 rows. 
Condition took 0.86 seconds to convert 461 rows. 
Total time: 3.185586916981265
```
(readout edited for easy comparison)